### PR TITLE
Implement automatic WAN failover between Ethernet and WiFi

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -69,6 +69,11 @@ cp /tmp/overlay/rc-local.service /etc/systemd/system/rc-local.service
 systemctl enable rc-local.service
 #--------------------------------------------------------------------------------------------
 
+## WAN Failover #################################################################################
+# netplan sample configuration with WiFi
+cp /tmp/overlay/wan-failover/10-dhcp-all-interfaces.yaml /etc/netplan/10-dhcp-all-interfaces.yaml
+#--------------------------------------------------------------------------------------------
+
 ## Add install.sh ###########################################################################
 cp /tmp/overlay/install.sh /opt/web3pi/.install.sh     # Copy the install script to /opt/web3pi
 chmod +x /opt/web3pi/.install.sh
@@ -81,6 +86,7 @@ apt install -y software-properties-common apt-utils chrony avahi-daemon git git-
 apt install -y python3-pip python3-netifaces python3-dev libpython3-dev python3-venv
 apt install -y nvme-cli jq speedtest-cli file vim net-tools telnet apt-transport-https gdisk
 apt install -y gcc libraspberrypi-bin iotop screen bpytop ccze iw flashrom figlet neofetch dphys-swapfile
+apt install -y iproute2 iputils-ping dnsutils gawk bsdutils # for Wan Failover script
 #--------------------------------------------------------------------------------------------
 
 ## UFW (firewall) ###########################################################################

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -78,6 +78,12 @@ chown -R ethereum:ethereum /opt/web3pi/wan-failover
 
 cp /tmp/overlay/wan-failover/wan-failover.sh /opt/web3pi/wan-failover/wan-failover.sh
 chmod +x /opt/web3pi/wan-failover/wan-failover.sh
+
+# Copy the w3p-wan-failover service file
+cp /tmp/overlay/wan-failover/w3p-wan-failover.service /etc/systemd/system/w3p-wan-failover.service
+
+# Enable the WanFailover service
+systemctl enable w3p-wan-failover.service
 #--------------------------------------------------------------------------------------------
 
 ## Add install.sh ###########################################################################

--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -72,6 +72,12 @@ systemctl enable rc-local.service
 ## WAN Failover #################################################################################
 # netplan sample configuration with WiFi
 cp /tmp/overlay/wan-failover/10-dhcp-all-interfaces.yaml /etc/netplan/10-dhcp-all-interfaces.yaml
+
+mkdir /opt/web3pi/wan-failover
+chown -R ethereum:ethereum /opt/web3pi/wan-failover
+
+cp /tmp/overlay/wan-failover/wan-failover.sh /opt/web3pi/wan-failover/wan-failover.sh
+chmod +x /opt/web3pi/wan-failover/wan-failover.sh
 #--------------------------------------------------------------------------------------------
 
 ## Add install.sh ###########################################################################

--- a/userpatches/overlay/install.sh
+++ b/userpatches/overlay/install.sh
@@ -333,6 +333,8 @@ else
     set_status "[install.sh] - Preparing $W3P_DRIVE for installation"
     prepare_disk $W3P_DRIVE
 fi
+
+chown ethereum:ethereum /mnt/storage # Set ownership to 'ethereum' user, after mounting the disk
 #--------------------------------------------------------------------------------------------
 
 ## SWAP SPACE CONFIGURATION ###################################################################

--- a/userpatches/overlay/wan-failover/10-dhcp-all-interfaces.yaml
+++ b/userpatches/overlay/wan-failover/10-dhcp-all-interfaces.yaml
@@ -1,0 +1,24 @@
+# Added by Armbian
+#
+# Reference: https://netplan.readthedocs.io/en/stable/netplan-yaml/
+#
+# Let systemd-networkd manage all Ethernet devices on this system, but be configured by Netplan.
+
+network:
+  version: 2
+  renderer: networkd
+  ethernets:
+    all-eth-interfaces:
+      match:
+        name: "e*"
+      dhcp4: yes
+      dhcp6: no
+      ipv6-privacy: yes # Enabled by default on most current systems, but networkd currently doesn't enable IPv6 privacy by >
+  # wifis:
+  #   wlan0:
+  #     dhcp4: yes
+  #     dhcp4-overrides:
+  #       route-metric: 200
+  #     access-points:
+  #       "YOUR_SSID_NAME":
+  #         password: "YOUR_WIFI_PASSWORD"

--- a/userpatches/overlay/wan-failover/w3p-wan-failover.service
+++ b/userpatches/overlay/wan-failover/w3p-wan-failover.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Automatic network failover (eth/wifi)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/opt/web3pi/wan-failover/wan-failover.sh
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/userpatches/overlay/wan-failover/wan-failover.sh
+++ b/userpatches/overlay/wan-failover/wan-failover.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+################################################################################
+# Simple Network Failover Script with DNS and Traffic/Downtime Reporting
+#
+# This script automatically switches outgoing internet traffic from a
+# PRIMARY interface (e.g. wired LAN) to a BACKUP interface (e.g. WiFi)
+# if connectivity via PRIMARY is lost (detected by failed ICMP ping
+# AND DNS resolution). When PRIMARY recovers, it switches back.
+#
+# It also tracks:
+#  - Total downtime spent on the backup interface
+#  - Volume of traffic (TX+RX bytes) sent via the backup interface
+#  - Logs statistics on each recovery event
+#
+# Requires: bash, iproute2, awk, ping, dig or nslookup
+# Must be run as root (for 'ip route ...' and access to /proc/net/dev)
+################################################################################
+
+# === CONFIGURATION ===
+
+# PRIMARY_IF:
+#   Main preferred interface for internet access (e.g. "end0", "eth0")
+PRIMARY_IF="end0"
+
+# BACKUP_IF:
+#   Backup/secondary interface (e.g. "wlan0")
+BACKUP_IF="wlan0"
+
+# PING_TARGETS:
+#   List of external IPv4 addresses for connectivity check (public DNS recommended)
+PING_TARGETS="1.1.1.1 8.8.8.8"
+
+# PING_COUNT:
+#   Number of ICMP echo requests per check, per target
+PING_COUNT=2
+
+# PING_TIMEOUT:
+#   Timeout (in seconds) per ICMP echo request
+PING_TIMEOUT=2
+
+# FAIL_THRESH:
+#   Minimum number of failed ping targets to trigger failover
+FAIL_THRESH=5
+
+# DNS_TEST_DOMAIN / DNS_RESOLVER:
+#   DNS test: domain name to resolve and DNS server IP to query.
+#   Failover occurs if DNS test fails as well.
+DNS_TEST_DOMAIN="google.com"
+DNS_RESOLVER="8.8.8.8"
+
+# CHECK_INTERVAL:
+#   How frequently (seconds) to check and possibly switch interfaces
+CHECK_INTERVAL=10
+
+################################################################################
+# ---- NO USER SETTINGS BELOW THIS POINT ----
+
+# Returns 0 (success) if interface $1 is up, 1 otherwise
+if_is_up() {
+    [[ "$(cat /sys/class/net/$1/operstate 2>/dev/null)" == "up" ]]
+}
+
+# Returns current default gateway IP for interface $1 (empty if down/not set)
+get_gw_by_if() {
+    IFACE="$1"
+    ip route | awk -v dev="$IFACE" '$1=="default" && $5==dev {print $3; exit}'
+}
+
+# Returns interface which owns current default route
+get_current_default_gwdev() {
+    ip route | awk '$1 == "default" {print $5; exit}'
+}
+
+# Returns number of PING_TARGETS for which ping fails
+check_ping() {
+    failcount=0
+    for IP in $PING_TARGETS; do
+        if ! ping -I "$PRIMARY_IF" -c "$PING_COUNT" -W "$PING_TIMEOUT" "$IP" > /dev/null; then
+            ((failcount++))
+        fi
+    done
+    echo "$failcount"
+}
+
+# Returns 0 if DNS is working (domain resolves to an IP), 1 if not
+check_dns() {
+    if command -v dig >/dev/null 2>&1; then
+        dig @"$DNS_RESOLVER" "$DNS_TEST_DOMAIN" +short | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'
+        return $?
+    else
+        nslookup "$DNS_TEST_DOMAIN" "$DNS_RESOLVER" 2>/dev/null | grep -q "Address: "
+        return $?
+    fi
+}
+
+# Returns total bytes (RX + TX) transferred on interface $1
+iface_bytes() {
+    IF="$1"
+    awk -v ifname="$IF" '$1 == ifname":" {print $2 + $10}' /proc/net/dev
+}
+
+################################################################################
+# ---- MAIN LOGIC ----
+
+# CURRENT_MODE:
+#   "primary" if PRIMARY_IF is active, "backup" if BACKUP_IF is used for default route.
+CURRENT_MODE="primary"
+
+# DOWNTIME_START:
+#   Holds Unix timestamp when failover starts (i.e., backup interface takes over)
+DOWNTIME_START=0
+
+# TOTAL_DOWNTIME:
+#   Accumulated failover duration (seconds) over one script run
+TOTAL_DOWNTIME=0
+
+# BACKUP_BYTES_START:
+#   Value of RX+TX bytes for BACKUP_IF when failover begins
+BACKUP_BYTES_START=0
+
+# BACKUP_BYTES_TOTAL:
+#   Accumulated number of bytes sent via BACKUP_IF over all failover intervals
+BACKUP_BYTES_TOTAL=0
+
+while true; do
+    # 1. Check if both interfaces are physically up
+    if if_is_up "$PRIMARY_IF"; then
+        PRIMARY_OK=1
+    else
+        PRIMARY_OK=0
+    fi
+    if if_is_up "$BACKUP_IF"; then
+        BACKUP_OK=1
+    else
+        BACKUP_OK=0
+    fi
+
+    # 2. Connectivity tests:
+    FAILS=$(check_ping)
+    check_dns
+    DNS_OK=$?
+
+    # 3. Get dynamic current DHCP gateways
+    PRIMARY_GW=$(get_gw_by_if "$PRIMARY_IF")
+    BACKUP_GW=$(get_gw_by_if "$BACKUP_IF")
+    CUR_GWDEV=$(get_current_default_gwdev)
+
+    # Log status for debugging / observation
+    echo "PINGfails:$FAILS DNS:$DNS_OK PRIMARY_GW:$PRIMARY_GW BACKUP_GW:$BACKUP_GW DEF_IF:$CUR_GWDEV"
+
+    #####################
+    # Main switching logic
+    #
+    # If using primary, check for failover conditions (ICMP/DNS/iface fail)
+    if [[ "$CURRENT_MODE" == "primary" ]]; then
+        if (( FAILS >= FAIL_THRESH )) || [[ $PRIMARY_OK -eq 0 ]] || [[ $DNS_OK -ne 0 ]]; then
+            if [[ -n "$BACKUP_GW" ]] && [[ $BACKUP_OK -eq 1 ]]; then
+                echo "FAILOVER: Switching to backup: $BACKUP_IF gw $BACKUP_GW (Ping/DNS failed or IF down)"
+                ip route replace default via "$BACKUP_GW" dev "$BACKUP_IF"
+                CURRENT_MODE="backup"
+                DOWNTIME_START=$(date +%s)
+                BACKUP_BYTES_START=$(iface_bytes "$BACKUP_IF")
+            else
+                echo "Failover blocked: Backup $BACKUP_IF unavailable (not up or no gateway)"
+            fi
+        fi
+    #
+    # If using backup, check for recovery (primary restored: ICMP+DNS+gateway+UP)
+    else
+        if (( FAILS < FAIL_THRESH )) && [[ $PRIMARY_OK -eq 1 ]] && [[ $DNS_OK -eq 0 ]] && [[ -n "$PRIMARY_GW" ]]; then
+            echo "RECOVERY: Switching back to primary: $PRIMARY_IF gw $PRIMARY_GW"
+            ip route replace default via "$PRIMARY_GW" dev "$PRIMARY_IF"
+            # Calculate and display failover stats:
+            NOW=$(date +%s)
+            DURATION=$(( NOW - DOWNTIME_START ))
+            TOTAL_DOWNTIME=$(( TOTAL_DOWNTIME + DURATION ))
+            CUR_BACKUP_BYTES=$(iface_bytes "$BACKUP_IF")
+            USAGE=$(( CUR_BACKUP_BYTES - BACKUP_BYTES_START ))
+            BACKUP_BYTES_TOTAL=$(( BACKUP_BYTES_TOTAL + USAGE ))
+
+            echo "---- FAILOVER STATS ----"
+            echo "Downtime (latest event): $DURATION sec"
+            echo "Traffic sent on backup:  $USAGE bytes"
+            echo "Total downtime:          $TOTAL_DOWNTIME sec"
+            echo "Total traffic on backup: $BACKUP_BYTES_TOTAL bytes"
+            echo "------------------------"
+
+            # Reset per-event counters
+            DOWNTIME_START=0
+            BACKUP_BYTES_START=0
+            CURRENT_MODE="primary"
+        #
+        # Backup interface has disappeared altogether (WiFi disconnected?)
+        elif ! if_is_up "$BACKUP_IF"; then
+            echo "WARNING: Backup IF $BACKUP_IF has gone! Default route deleted."
+            ip route del default
+            CURRENT_MODE="unknown"
+        fi
+    fi
+
+    sleep "$CHECK_INTERVAL"
+done


### PR DESCRIPTION
### Add WAN Failover Functionality (Ethernet → WiFi)

This PR introduces automatic WAN failover support.

* The **primary connection** is via wired Ethernet.
* The **backup connection** is WiFi.

A background service `w3p-wan-failover.service` runs the script `/opt/web3pi/wan-failover/wan-failover.sh`.
It monitors the primary interface using both **ping** and **DNS checks**.
If connectivity is lost, it switches to the WiFi interface by adjusting interface metrics.
When the primary link is restored, the script reverts to Ethernet and displays statistics showing how much data was used over the backup connection.

---

### ⚙️ Network Configuration Required

Manually edit the file:

```
/etc/netplan/10-dhcp-all-interfaces.yaml
```

Uncomment the **WiFi section** and provide your SSID and password.

> ⚠️ Be careful with indentation – YAML is whitespace-sensitive.
