### PR TITLE
Add apcupsd setup for APC UPS with automated shutdown and event handling

### DIFF
--- a/userpatches/customize-image.sh
+++ b/userpatches/customize-image.sh
@@ -166,6 +166,33 @@ git-force-clone -b master https://github.com/raspberrypi/rpi-eeprom /opt/web3pi/
 # This is later used in install.sh to update the firmware
 #--------------------------------------------------------------------------------------------
 
+## UPS APC ##################################################################################
+sed -i 's/^ISCONFIGURED=.*/ISCONFIGURED=yes/' /etc/default/apcupsd # Mark apcupsd as configured
+
+mkdir /opt/web3pi/ups
+chown -R ethereum:ethereum /opt/web3pi/ups
+
+cp /tmp/overlay/ups/apcupsd.conf /etc/apcupsd/apcupsd.conf # Configure USB UPS
+
+cp /tmp/overlay/ups/scripts/* /opt/web3pi/ups/ # Copy UPS scripts
+chmod +x /opt/web3pi/ups/*.sh
+
+# Deploy custom hooks
+echo '#!/bin/bash
+/opt/web3pi/ups/power_lost.sh' > /etc/apcupsd/onbattery
+
+echo '#!/bin/bash
+/opt/web3pi/ups/power_restored.sh' > /etc/apcupsd/offbattery
+
+echo '#!/bin/bash
+/opt/web3pi/ups/graceful_shutdown.sh' > /etc/apcupsd/doshutdown
+
+chmod +x /etc/apcupsd/onbattery /etc/apcupsd/offbattery /etc/apcupsd/doshutdown
+
+# Enable apcupsd service
+systemctl enable apcupsd
+#--------------------------------------------------------------------------------------------
+
 ## Security hardening #######################################################################
 # Lock the root account
 passwd --lock root

--- a/userpatches/overlay/ups/apcupsd.conf
+++ b/userpatches/overlay/ups/apcupsd.conf
@@ -1,0 +1,36 @@
+## apcupsd.conf v1.1 ##
+# Minimal configuration for APC UPS connected via USB
+
+UPSCABLE usb
+UPSTYPE usb
+DEVICE
+
+LOCKFILE /var/lock
+SCRIPTDIR /etc/apcupsd
+PWRFAILDIR /etc/apcupsd
+NOLOGINDIR /etc
+
+ONBATTERYDELAY 6
+BATTERYLEVEL 20
+MINUTES 10
+TIMEOUT 0
+
+ANNOY 300
+ANNOYDELAY 60
+NOLOGON disable
+KILLDELAY 0
+
+NETSERVER on
+NISIP 0.0.0.0
+NISPORT 3551
+
+EVENTSFILE /var/log/apcupsd.events
+EVENTSFILEMAX 10
+
+UPSCLASS standalone
+UPSMODE disable
+
+STATTIME 0
+STATFILE /var/log/apcupsd.status
+LOGSTATS off
+DATATIME 0

--- a/userpatches/overlay/ups/scripts/graceful_shutdown.sh
+++ b/userpatches/overlay/ups/scripts/graceful_shutdown.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+LOG_FILE="/opt/web3pi/logs/ups-events.log"
+echo "[$(date)] UPS battery critical – initiating graceful shutdown" >> "$LOG_FILE"
+
+# Lista procesów do zatrzymania
+APPS=("geth" "nimbus_beacon_node" "nimbus_validator_client" "lighthouse")
+
+for APP in "${APPS[@]}"; do
+  PID=$(pidof "$APP")
+  if [ -n "$PID" ]; then
+    echo "[$(date)] Stopping $APP (PID $PID)" >> "$LOG_FILE"
+    kill -SIGTERM "$PID"
+
+    # Czekamy aż proces się zakończy
+    for i in {1..30}; do
+      sleep 1
+      if ! pidof "$APP" >/dev/null; then
+        echo "[$(date)] $APP stopped successfully" >> "$LOG_FILE"
+        break
+      fi
+    done
+
+    # Jeśli nadal żyje – SIGKILL
+    if pidof "$APP" >/dev/null; then
+      echo "[$(date)] $APP did not stop in time, forcing kill" >> "$LOG_FILE"
+      kill -9 "$PID"
+    fi
+  else
+    echo "[$(date)] $APP not running" >> "$LOG_FILE"
+  fi
+done
+
+echo "[$(date)] All apps stopped, shutting down system..." >> "$LOG_FILE"
+shutdown -h now

--- a/userpatches/overlay/ups/scripts/power_lost.sh
+++ b/userpatches/overlay/ups/scripts/power_lost.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "[$(date)] ⚠️ UPS: Power lost" >> /opt/web3pi/logs/ups-events.log

--- a/userpatches/overlay/ups/scripts/power_restored.sh
+++ b/userpatches/overlay/ups/scripts/power_restored.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "[$(date)] ✅ UPS: Power restored" >> /opt/web3pi/logs/ups-events.log


### PR DESCRIPTION
Add support for APC UPS over USB.
Events on power loss, power restore, and graceful shutdown at 20% battery.

Scripts:
/opt/web3pi/ups/power_lost.sh
/opt/web3pi/ups/power_restored.sh
/opt/web3pi/ups/graceful_shutdown.sh

Logs:
/opt/web3pi/logs/ups-events.log

<img width="633" height="997" alt="UPS" src="https://github.com/user-attachments/assets/a6d07474-40ee-40d8-aefe-85049c863537" />
